### PR TITLE
Increase file path length for gridshift file loading on iOS.

### DIFF
--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -180,7 +180,10 @@ PJ_GRIDINFO **pj_gridlist_from_nadgrids( projCtx ctx, const char *nadgrids,
     {
         int   end_char;
         int   required = 1;
-        char  name[128];
+
+        // Original hardcoded path of 128 chars is too small for iOS paths,
+        // which contain a large UUID as part of their path. 512 is sufficient.
+        char  name[512];
 
         if( *s == '@' )
         {


### PR DESCRIPTION
When trying to load a grid shift file on iOS, it always fails due to the app sandbox directory being a rather large UUID, which overflows the hard-coded limit of 128 chars in the `pj_gridlist_from_nadgrids` function.

This PR increases the limit to 512, which provides adequate headroom for even the most egregiously long file paths.
